### PR TITLE
refactor: Color pallete 네이밍 개선

### DIFF
--- a/libs/ui/src/Icons/icons.css.tsx
+++ b/libs/ui/src/Icons/icons.css.tsx
@@ -1,4 +1,5 @@
 import { style } from '@vanilla-extract/css';
+import { styleToken } from '../core';
 
 export const IconWrapperStyle = style({
   display: 'flex',
@@ -22,5 +23,5 @@ export const WrapperStyle = style({
   colGap: 30,
   rowGap: 10,
   border: '1px solid black',
-  backgroundColor: '#f6f6f6',
+  backgroundColor: styleToken.color.coolGray,
 });

--- a/libs/ui/src/components/BottomNavigation/BottomNavigation.css.ts
+++ b/libs/ui/src/components/BottomNavigation/BottomNavigation.css.ts
@@ -16,7 +16,7 @@ export const NavigationButton = style({
   alignItems: 'center',
   justifyContent: 'center',
   backgroundColor: color.white,
-  color: color.grayPrimary,
+  color: color.gray1,
   fontWeight: 700,
   fontSize: 10,
   flex: 1,

--- a/libs/ui/src/components/BottomNavigation/BottomNavigation.tsx
+++ b/libs/ui/src/components/BottomNavigation/BottomNavigation.tsx
@@ -38,7 +38,7 @@ export const BottomNavigation = ({ activePath = '/', onNavigate, className }: Pr
             onNavigate?.(path);
           }}
         >
-          <Icon color={path === activePath ? color.primary : color.graySecondary} />
+          <Icon color={path === activePath ? color.primary : color.gray2} />
         </Button>
       ))}
     </nav>

--- a/libs/ui/src/components/Button/Button.css.ts
+++ b/libs/ui/src/components/Button/Button.css.ts
@@ -31,7 +31,7 @@ export const ButtonTypeStyle: { [K in ButtonType]: string } = {
     },
   }),
   Line: style({
-    border: `1px solid ${color.graySecondary}`,
+    border: `1px solid ${color.gray2}`,
     backgroundColor: color.white,
     color: color.black,
 
@@ -41,7 +41,7 @@ export const ButtonTypeStyle: { [K in ButtonType]: string } = {
     },
 
     ':active': {
-      border: `1px solid ${color.grayPrimary}`,
+      border: `1px solid ${color.gray1}`,
     },
   }),
   '': style({}),

--- a/libs/ui/src/components/Token/token.css.ts
+++ b/libs/ui/src/components/Token/token.css.ts
@@ -1,4 +1,5 @@
 import { style } from '@vanilla-extract/css';
+import { styleToken } from '../../core';
 
 export const colorContainer = style({
   display: 'flex',
@@ -22,5 +23,5 @@ export const rootContainer = style({
   colGap: 30,
   rowGap: 10,
   border: '1px solid black',
-  backgroundColor: '#f6f6f6',
+  backgroundColor: styleToken.color.coolGray,
 });

--- a/libs/ui/src/core/styleToken.css.ts
+++ b/libs/ui/src/core/styleToken.css.ts
@@ -4,9 +4,11 @@ export const COLOR_PROPERTIES = {
   primary: '#3673EE',
   secondary: '#EE3636',
 
-  grayPrimary: '#858B93',
-  graySecondary: '#D6D8DB',
-  grayLight: '#F6F6F6',
+  gray1: '#858B93',
+  gray2: '#D6D8DB',
+  gray3: '#E6E8EB',
+  darkGray: '#616161',
+  coolGray: '#F6F6F6',
 
   black: '#131313',
   white: '#FFFFFF',


### PR DESCRIPTION
## 작업 주제

- 컬러 팔레트 네이밍 개선

## 작업 내용(어떤 부분을 리뷰어가 집중해서 봐야할까요?)

- gray 색상이 피그마와 동일하게 네이밍을 변경했어요.
- 추가로 색상을 사용하고 있는 경우 토큰에서 활용하도록 변경했습니다.

## optional 화면 스크린샷

![image](https://github.com/project-oseek/oseek/assets/39726717/30857d30-f0fd-46d2-bee6-ab1dcf846a52)


## 체크리스트(PR 올리기 전 아래의 내용을 확인해주세요.)

- [x] base, compare branch가 적절하게 선택되었나요?
- [x] 로컬 환경에서 충분히 테스트 하셨나요?

## 리뷰 규칙

- P1: 꼭/적극적 반영해 주세요 (Request changes)
- P2: 웬만하면 반영해 주세요 (Comment)
- P3: 반영해도 좋고 넘어가도 좋습니다 (Approve)
